### PR TITLE
Feature: Add GitHub issue/pull request templates based on other projects

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Subject
+
+
+<!--
+    Give here as many details as possible.
+    Next sections are for ERRORS only.
+-->
+
+## Steps to reproduce
+
+## Expected results
+
+## Actual results

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
+
+## Title
+{title}
+
+## Changelog
+
+<!-- MANDATORY
+    Fill the changelog part inside the code block.
+    Follow this schema: http://keepachangelog.com/
+-->
+
+<!-- REMOVE EMPTY SECTIONS -->
+```markdown
+### Added
+- Added some `Class::newMethod` to do great stuff
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+```
+
+## To do
+
+<!--
+    If this is a work in progress, COMPLETE and ADD needed tasks.
+    You can add as many tasks as you want.
+    If some are not relevant, just REMOVE them.
+-->
+
+- [ ] Update the documentation
+- [ ] Add an upgrade note
+
+## Subject
+
+<!-- Describe your Pull Request content here -->


### PR DESCRIPTION
I think it's an good idea to have some kind of template for pullrequests/issues.
I will propose some templates I think are quite handy, based on Sonata Project and Symfony.