### PR TITLE
Feature: Add configuration option for extra assets

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,8 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('custom_theme')->defaultValue('')->end()
+                ->arrayNode('extra_css_assets')->prototype('scalar')->end()->end()
+                ->arrayNode('extra_js_assets')->prototype('scalar')->end()->end()
             ->end()
         ;
 

--- a/DependencyInjection/JustSonataThemeExtension.php
+++ b/DependencyInjection/JustSonataThemeExtension.php
@@ -43,17 +43,17 @@ class JustSonataThemeExtension extends Extension implements PrependExtensionInte
 
         if ($theme = $config['custom_theme']) {
             $yml = $this->parseYml($container->getParameter('kernel.root_dir') . '/' . $theme);
-            $extensionConfig = array_replace_recursive($extensionConfig, $yml);
 
-            if (isset($yml['extra_css'])) {
+            if (isset($yml['extra_css']) && $yml['extra_css']) {
                 $extensionConfig['assets']['stylesheets'] = array_merge($extensionConfig['assets']['stylesheets'], $yml['extra_css']);
-                unset($extensionConfig['extra_css']);
             }
-            if (isset($yml['extra_js'])) {
+            if (isset($yml['extra_js']) && $yml['extra_js']) {
                 $extensionConfig['assets']['javascripts'] = array_merge($extensionConfig['assets']['javascripts'], $yml['extra_js']);
-                unset($extensionConfig['extra_js']);
             }
         }
+
+        $extensionConfig['assets']['javascripts'] = array_merge($extensionConfig['assets']['javascripts'], $config['extra_js_assets']);
+        $extensionConfig['assets']['stylesheets'] = array_merge($extensionConfig['assets']['stylesheets'], $config['extra_css_assets']);
 
         $container->prependExtensionConfig('sonata_admin', $extensionConfig);
     }


### PR DESCRIPTION
## Feature: Add configuration option for extra assets
This enables you to hook into this bundle using prepend().

```php
    // Other bundle extension

    /**
     * Allow an extension to prepend the extension configurations.
     *
     * @param ContainerBuilder $container
     */
    public function prepend(ContainerBuilder $container)
    {
        if ($container->hasExtension('just_sonata_theme')) {
            $container->prependExtensionConfig('just_sonata_theme', [
                'extra_css_assets' => [
                    xxx'
                ],
                'extra_js_assets' => [
                    'xxx',
                ],
            ]);
        }
    }

```

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new configuration option (array) for extra js/css assets
```